### PR TITLE
Updated android target to 9.0

### DIFF
--- a/src/BeerTrade/BeerTrade.Android/BeerTrade.Android.csproj
+++ b/src/BeerTrade/BeerTrade.Android/BeerTrade.Android.csproj
@@ -15,7 +15,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
     <AndroidEnableSGenConcurrent>true</AndroidEnableSGenConcurrent>
     <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp>

--- a/src/BeerTrade/BeerTrade.Android/Properties/AndroidManifest.xml
+++ b/src/BeerTrade/BeerTrade.Android/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="dev.codemonkeys.beertrade">
-	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="27" />
+	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="28" />
 	<application android:label="BeerTrade.Android"></application>
 </manifest>


### PR DESCRIPTION
When I added FFImageLoading Transformations in android project, an warning about android target appear in console. To use this library correctily is necessary update the android target to 9.0.

This pull request will useful when https://github.com/MonkeyNights/beer-trade/pull/39 will be merged.